### PR TITLE
Added CloudWatchAlarmSimulator and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@ Transport tribe library for common CDK components
 
 # Dev environment
 You can create a dev virtualenv by running `tox -e dev --devenv .venv` from the repo's root folder
+
+# Components
+
+## Prereq/configuration for CDK Pipelines
+
+TODO: put something here? Chris might be doing this?
+
+## CDK constructs
+
+This library contains a number of CDK constructs under cdkutils.constructs. These are described in the [constructs README](src/cdkutils/constructs/README.md)
+
+## Test helpers
+
+This library also contains some test helpers under cdkutils.test_helpers. These are described in the [test helpers README](src/cdkutils/test_helpers/README.md)

--- a/src/cdkutils/config.py
+++ b/src/cdkutils/config.py
@@ -385,7 +385,7 @@ class ServiceDetails(PersistedConfig):
             and self.cost_code == other.cost_code
         )
 
-    def apply_tags_to(self, scope: cdk.Construct) -> None:
+    def apply_tags_to(self, scope: cdk.IConstruct) -> None:
         """Apply Tags using this instance's values"""
         tag_scope = cdk.Tags.of(scope)
         for tag_name, tag_value in [

--- a/src/cdkutils/constructs/README.md
+++ b/src/cdkutils/constructs/README.md
@@ -1,0 +1,3 @@
+# Constructs
+
+This is a placeholder for documentation of the CDK constructs for when they're moved across

--- a/src/cdkutils/test_helpers/README.md
+++ b/src/cdkutils/test_helpers/README.md
@@ -34,3 +34,19 @@ alarm_states = cloudwatch_alarm_simulator.run_simulation([alerting_metrics])
 expected_alarm_states = CloudWatchAlarmSimulator.make_simulation_result(len(alerting_metric_values), list(range(first_alert_expected, no_files_first_end)) + list(range(second_alert_expected, no_files_second_end)))
 self.assertEqual(alarm_states, expected_alarm_states)
 ```
+
+The result of a simulation looks like this:
+```
+{
+    1: 'OK',
+    2: 'ALARM',
+    3: 'ALARM',
+    ...
+}
+```
+
+The convenience static method 
+```
+CloudWatchAlarmSimulator.make_simulation_result(length, alarm)
+```
+produces a dict in this format of length {length} with 'ALARM' states at the indices provides in the list {alarm} and all other indices 'OK'

--- a/src/cdkutils/test_helpers/README.md
+++ b/src/cdkutils/test_helpers/README.md
@@ -1,0 +1,36 @@
+# Test helpers
+
+This subpackage contains test helpers for CDK code
+
+## CloudWatchAlarmSimulator
+
+This is designed to simulate the behaviour of a CloudWatch alarm.
+In order to use it, you should have access to an aws_cloudwatch.AlarmProps object, which is initialised with the same properties your alarm is using.
+These are available within the constructs provided in this library as alarm.alarm_props, but if you create an alarm without using these, you will have to set it up yourself.
+
+Currently this library only supports testing of single metric alarms.
+
+Usage example:
+```python
+from cdkutils.test_helpers import CloudWatchAlarmSimulator
+
+
+icing_alarm_props = test_dashboard_stack.alarm.alarm_props
+cloudwatch_alarm_simulator = CloudWatchAlarmSimulator(icing_alarm_props)
+        
+# Alarm is configured with 144 evaluation periods, so we expect it to start alerting 144 after start of
+# each outage period
+evaluation_periods = icing_alarm_props.evaluation_periods
+no_files_first_start = 20
+no_files_first_end = 170
+no_files_second_start = 190
+no_files_second_end = 343
+first_alert_expected = no_files_first_start + evaluation_periods
+second_alert_expected = no_files_second_start + evaluation_periods
+
+alerting_metric_values = [0 if no_files_first_start < i < no_files_first_end or no_files_second_start < i < no_files_second_end else 1 for i in range(350)]
+alerting_metrics = {"metric": icing_alarm_props.metric, "values": alerting_metric_values}
+alarm_states = cloudwatch_alarm_simulator.run_simulation([alerting_metrics])
+expected_alarm_states = CloudWatchAlarmSimulator.make_simulation_result(len(alerting_metric_values), list(range(first_alert_expected, no_files_first_end)) + list(range(second_alert_expected, no_files_second_end)))
+self.assertEqual(alarm_states, expected_alarm_states)
+```

--- a/src/cdkutils/test_helpers/__init__.py
+++ b/src/cdkutils/test_helpers/__init__.py
@@ -1,0 +1,1 @@
+from .cloudwatch_alarm_simulator import CloudWatchAlarmSimulator

--- a/src/cdkutils/test_helpers/__init__.py
+++ b/src/cdkutils/test_helpers/__init__.py
@@ -1,1 +1,1 @@
-from .cloudwatch_alarm_simulator import CloudWatchAlarmSimulator
+from .cloudwatch_alarm_simulator import CloudWatchAlarmSimulator, MetricException

--- a/src/cdkutils/test_helpers/cloudwatch_alarm_simulator.py
+++ b/src/cdkutils/test_helpers/cloudwatch_alarm_simulator.py
@@ -1,0 +1,38 @@
+from typing import Any, Dict, List
+
+from aws_cdk import aws_cloudwatch
+
+ALARM_STATE_OK = "OK"
+ALARM_STATE_ALARM = "ALARM"
+
+
+class CloudWatchAlarmSimulator:
+    def __init__(self, alarm_definition: aws_cloudwatch.AlarmProps):
+        self.alarm_definition = alarm_definition
+
+    def run_simulation(self, metrics: List[Dict[str, Any]]) -> Dict[int, str]:
+        for metric in metrics:
+            if metric["metric"] == self.alarm_definition.metric:
+                return {i: self.check_evaluation_period(i, metric["values"]) for i in range(len(metric["values"]))}
+        raise Exception(f"Metric {self.alarm_definition.metric} not found!")
+
+    def check_evaluation_period(self, period: int, metric_values: List[float]) -> str:
+        evaluation_periods = int(self.alarm_definition.evaluation_periods)
+        metric_set = metric_values[max(1 + period - evaluation_periods, 0) : period + 1]
+        if all(self.check_breaching(metric) for metric in metric_set):
+            return ALARM_STATE_ALARM
+        return ALARM_STATE_OK
+
+    def check_breaching(self, metric: float) -> bool:
+        if self.alarm_definition.treat_missing_data == aws_cloudwatch.TreatMissingData.BREACHING and metric is None:
+            return True
+        if (
+            self.alarm_definition.comparison_operator == aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD
+            and metric < self.alarm_definition.threshold
+        ):
+            return True
+        return False
+
+    @staticmethod
+    def make_simulation_result(length: int, alarm: List[int]) -> Dict[int, str]:
+        return {i: "ALARM" if i in alarm else "OK" for i in range(length)}

--- a/src/cdkutils/test_helpers/cloudwatch_alarm_simulator.py
+++ b/src/cdkutils/test_helpers/cloudwatch_alarm_simulator.py
@@ -6,6 +6,10 @@ ALARM_STATE_OK = "OK"
 ALARM_STATE_ALARM = "ALARM"
 
 
+class MetricException(Exception):
+    pass
+
+
 class CloudWatchAlarmSimulator:
     def __init__(self, alarm_definition: aws_cloudwatch.AlarmProps):
         self.alarm_definition = alarm_definition
@@ -14,7 +18,7 @@ class CloudWatchAlarmSimulator:
         for metric in metrics:
             if metric["metric"] == self.alarm_definition.metric:
                 return {i: self.check_evaluation_period(i, metric["values"]) for i in range(len(metric["values"]))}
-        raise Exception(f"Metric {self.alarm_definition.metric} not found!")
+        raise MetricException(f"Metric {self.alarm_definition.metric} not found!")
 
     def check_evaluation_period(self, period: int, metric_values: List[float]) -> str:
         evaluation_periods = int(self.alarm_definition.evaluation_periods)

--- a/src/cdkutils/test_helpers/cloudwatch_alarm_simulator.py
+++ b/src/cdkutils/test_helpers/cloudwatch_alarm_simulator.py
@@ -24,7 +24,7 @@ class MetricException(Exception):
 
 
 class CloudWatchAlarmSimulator:
-    def __init__(self, alarm_definition: aws_cloudwatch.AlarmProps):
+    def __init__(self, alarm_definition: aws_cloudwatch.AlarmProps) -> None:
         self.alarm_definition = alarm_definition
 
     def run_simulation(self, metrics: List[Dict[str, Any]]) -> Dict[int, str]:
@@ -48,4 +48,4 @@ class CloudWatchAlarmSimulator:
 
     @staticmethod
     def make_simulation_result(length: int, alarm: List[int]) -> Dict[int, str]:
-        return {i: "ALARM" if i in alarm else "OK" for i in range(length)}
+        return {i: ALARM_STATE_ALARM if i in alarm else ALARM_STATE_OK for i in range(length)}

--- a/test/test_cloudwatch_alarm_simulator.py
+++ b/test/test_cloudwatch_alarm_simulator.py
@@ -3,7 +3,7 @@ import unittest
 from aws_cdk import aws_cloudwatch, core
 from parameterized import parameterized
 
-from cdkutils.test_helpers import CloudWatchAlarmSimulator
+from cdkutils.test_helpers import CloudWatchAlarmSimulator, MetricException
 
 TEST_METRIC = aws_cloudwatch.Metric(
     metric_name="PutRequests",
@@ -25,7 +25,7 @@ STALE_DATA_ALARM_DEFINITION = aws_cloudwatch.AlarmProps(
 DATA_STALE_AFTER_5_PERIODS = [{"metric": TEST_METRIC, "values": [1, 1, 0, 0, 0, 1]}]
 DATA_STALE_AFTER_5_PERIODS_RESULT = CloudWatchAlarmSimulator.make_simulation_result(length=6, alarm=[4])
 DATA_WRONG_METRIC = [{"metric": aws_cloudwatch.Metric(metric_name="bad_metric", namespace="bad"), "values": [1, 1, 1]}]
-DATA_WRONG_METRIC_RESULT = Exception(f"Metric {TEST_METRIC} not found!")
+DATA_WRONG_METRIC_RESULT = MetricException(f"Metric {TEST_METRIC} not found!")
 DATA_STALE_TWICE = [{"metric": TEST_METRIC, "values": [1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0]}]
 DATA_STALE_TWICE_RESULT = CloudWatchAlarmSimulator.make_simulation_result(length=12, alarm=[4, 8])
 DATA_NEVER_STALE = [{"metric": TEST_METRIC, "values": [1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0]}]

--- a/test/test_cloudwatch_alarm_simulator.py
+++ b/test/test_cloudwatch_alarm_simulator.py
@@ -1,0 +1,58 @@
+import unittest
+
+from aws_cdk import aws_cloudwatch, core
+from parameterized import parameterized
+
+from cdkutils.test_helpers import CloudWatchAlarmSimulator
+
+TEST_APP = core.Stack()
+TEST_METRIC = aws_cloudwatch.Metric(
+    metric_name="PutRequests",
+    namespace="AWS/S3",
+    dimensions={
+        "BucketName": "test_bucket",
+        "FilterId": "test_filter",
+    },
+)
+STALE_DATA_ALARM_DEFINITION = aws_cloudwatch.AlarmProps(
+    evaluation_periods=3,
+    statistic="sum",
+    metric=TEST_METRIC,
+    period=core.Duration.minutes(5),
+    threshold=1,
+    comparison_operator=aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+    treat_missing_data=aws_cloudwatch.TreatMissingData.BREACHING,
+)
+DATA_STALE_AFTER_5_PERIODS = [{"metric": TEST_METRIC, "values": [1, 1, 0, 0, 0, 1]}]
+DATA_STALE_AFTER_5_PERIODS_RESULT = CloudWatchAlarmSimulator.make_simulation_result(length=6, alarm=[4])
+DATA_WRONG_METRIC = [{"metric": aws_cloudwatch.Metric(metric_name="bad_metric", namespace="bad"), "values": [1, 1, 1]}]
+DATA_WRONG_METRIC_RESULT = Exception(f"Metric {TEST_METRIC} not found!")
+DATA_STALE_TWICE = [{"metric": TEST_METRIC, "values": [1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0]}]
+DATA_STALE_TWICE_RESULT = CloudWatchAlarmSimulator.make_simulation_result(length=12, alarm=[4, 8])
+DATA_NEVER_STALE = [{"metric": TEST_METRIC, "values": [1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0]}]
+DATA_NEVER_STALE_RESULT = CloudWatchAlarmSimulator.make_simulation_result(length=12, alarm=[])
+
+
+class CloudWatchAlarmSimulatorTestBase(unittest.TestCase):
+    def run_test_definition_with_metrics(self, alarm_definition, metrics, expected_result):
+        alarm_simulator = CloudWatchAlarmSimulator(alarm_definition)
+        if isinstance(expected_result, Exception):
+            with self.assertRaises(Exception) as e:
+                alarm_simulator.run_simulation(metrics)
+            self.assertEqual(str(e.exception), str(expected_result))
+        else:
+            result = alarm_simulator.run_simulation(metrics)
+            self.assertEqual(result, expected_result)
+
+
+class TestStaleDataAlarmSimulator(CloudWatchAlarmSimulatorTestBase):
+    @parameterized.expand(
+        [
+            (STALE_DATA_ALARM_DEFINITION, DATA_STALE_AFTER_5_PERIODS, DATA_STALE_AFTER_5_PERIODS_RESULT),
+            (STALE_DATA_ALARM_DEFINITION, DATA_WRONG_METRIC, DATA_WRONG_METRIC_RESULT),
+            (STALE_DATA_ALARM_DEFINITION, DATA_STALE_TWICE, DATA_STALE_TWICE_RESULT),
+            (STALE_DATA_ALARM_DEFINITION, DATA_NEVER_STALE, DATA_NEVER_STALE_RESULT),
+        ]
+    )
+    def test_definition_with_metrics(self, alarm_definition, metrics, expected_result):
+        self.run_test_definition_with_metrics(alarm_definition, metrics, expected_result)

--- a/test/test_cloudwatch_alarm_simulator.py
+++ b/test/test_cloudwatch_alarm_simulator.py
@@ -30,6 +30,9 @@ DATA_STALE_TWICE = [{"metric": TEST_METRIC, "values": [1, 1, 0, 0, 0, 1, 0, 0, 0
 DATA_STALE_TWICE_RESULT = CloudWatchAlarmSimulator.make_simulation_result(length=12, alarm=[4, 8])
 DATA_NEVER_STALE = [{"metric": TEST_METRIC, "values": [1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0]}]
 DATA_NEVER_STALE_RESULT = CloudWatchAlarmSimulator.make_simulation_result(length=12, alarm=[])
+DATA_MISSING_VALUES = [{"metric": TEST_METRIC, "values": [1, 1, 0, 1, None, 0, 0, None, 0, 1, 1, 0]}]
+DATA_MISSING_VALUES_RESULT = CloudWatchAlarmSimulator.make_simulation_result(length=12, alarm=[6, 7, 8])
+DATA_TWO_METRICS = [DATA_WRONG_METRIC[0], {"metric": TEST_METRIC, "values": [1, 1, 0, 0, 0, 1]}]
 
 
 class CloudWatchAlarmSimulatorTestBase(unittest.TestCase):
@@ -51,6 +54,8 @@ class TestStaleDataAlarmSimulator(CloudWatchAlarmSimulatorTestBase):
             (STALE_DATA_ALARM_DEFINITION, DATA_WRONG_METRIC, DATA_WRONG_METRIC_RESULT),
             (STALE_DATA_ALARM_DEFINITION, DATA_STALE_TWICE, DATA_STALE_TWICE_RESULT),
             (STALE_DATA_ALARM_DEFINITION, DATA_NEVER_STALE, DATA_NEVER_STALE_RESULT),
+            (STALE_DATA_ALARM_DEFINITION, DATA_MISSING_VALUES, DATA_MISSING_VALUES_RESULT),
+            (STALE_DATA_ALARM_DEFINITION, DATA_TWO_METRICS, DATA_STALE_AFTER_5_PERIODS_RESULT),
         ]
     )
     def test_definition_with_metrics(self, alarm_definition, metrics, expected_result):

--- a/test/test_cloudwatch_alarm_simulator.py
+++ b/test/test_cloudwatch_alarm_simulator.py
@@ -5,7 +5,6 @@ from parameterized import parameterized
 
 from cdkutils.test_helpers import CloudWatchAlarmSimulator
 
-TEST_APP = core.Stack()
 TEST_METRIC = aws_cloudwatch.Metric(
     metric_name="PutRequests",
     namespace="AWS/S3",

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     PyYAML~=5.4.1
     moto~=2.0.8
     pytest~=6.2.2
+    parameterized~=0.8.1
     coverage[toml]~=5.5 # toml extra is for pyproject support
 
 commands =
@@ -33,7 +34,6 @@ commands =
 
 [testenv:pylint]
 deps =
-    {[testenv]deps} # Install this projects specific test dependencies
     -r requirements/requirements-linting.txt
 commands =
     pylint --rcfile .pylintrc {toxinidir}/src/cdkutils


### PR DESCRIPTION
This is a second draft (essentially complete for now, would recommend if further alarm constructs are added, the tests are extended to cover them) of the CloudWatchAlarmSimulator. This has been tested with the alarms in aviation-data-services, once this is merged/released that PR will be available as well. 

I had to also add region_name={default} to all of the tests for config.py - not sure if this was down to having a newer version of boto3 available than it was originally tested with or something else coming into play.