### PR TITLE
[patch] Added safety to tox ini due to failing workflow

### DIFF
--- a/requirements/requirements-linting.txt
+++ b/requirements/requirements-linting.txt
@@ -1,5 +1,5 @@
 # Be aware, before renaming or moving this file, that it is referenced in .github/workflows/coding-standards.yml
-bginvoketasks~=1.0.0
+bginvoketasks~=0.0.7
 boto3-stubs~=1.17.93
 mypy_boto3_secretsmanager~=1.17.93
 mypy_boto3_ssm~=1.17.93

--- a/requirements/requirements-linting.txt
+++ b/requirements/requirements-linting.txt
@@ -1,5 +1,5 @@
 # Be aware, before renaming or moving this file, that it is referenced in .github/workflows/coding-standards.yml
-bginvoketasks~=0.0.7
+bginvoketasks~=1.0.0
 boto3-stubs~=1.17.93
 mypy_boto3_secretsmanager~=1.17.93
 mypy_boto3_ssm~=1.17.93

--- a/tooling.md
+++ b/tooling.md
@@ -10,6 +10,8 @@ standard way.
     * `mypy` (https://mypy.readthedocs.io/en/stable/)
     * `pylint` (https://pylint.pycqa.org/en/latest/)
     * `checkov` (https://www.checkov.io/documentation)
+    * `safety` (https://pyup.io/safety/)
+    * `pip-licenses` (https://github.com/raimon49/pip-licenses/blob/master/README.md)
     * SonarCloud (https://sonarcloud.io/) for collecting quality statistics
 * workflow & builds:
     * GitHub Actions (https://docs.github.com/en/actions) to do as much of our builds as possible

--- a/tooling.md
+++ b/tooling.md
@@ -10,8 +10,6 @@ standard way.
     * `mypy` (https://mypy.readthedocs.io/en/stable/)
     * `pylint` (https://pylint.pycqa.org/en/latest/)
     * `checkov` (https://www.checkov.io/documentation)
-    * `safety` (https://pyup.io/safety/)
-    * `pip-licenses` (https://github.com/raimon49/pip-licenses/blob/master/README.md)
     * SonarCloud (https://sonarcloud.io/) for collecting quality statistics
 * workflow & builds:
     * GitHub Actions (https://docs.github.com/en/actions) to do as much of our builds as possible

--- a/tox.ini
+++ b/tox.ini
@@ -36,3 +36,10 @@ deps =
     -r requirements/requirements-linting.txt
 commands =
     pylint --rcfile .pylintrc {toxinidir}/src/cdkutils
+
+[testenv:safety]
+deps =
+    safety~=1.10.3
+commands =
+    safety check
+

--- a/tox.ini
+++ b/tox.ini
@@ -46,5 +46,3 @@ commands =
 [testenv:pip-licenses]
 commands =
     pip-licenses {posargs}
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -36,13 +36,3 @@ deps =
     -r requirements/requirements-linting.txt
 commands =
     pylint --rcfile .pylintrc {toxinidir}/src/cdkutils
-
-[testenv:safety]
-deps =
-    safety~=1.10.3
-commands =
-    safety check
-
-[testenv:pip-licenses]
-commands =
-    pip-licenses {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,8 @@ deps =
 commands =
     safety check
 
+[testenv:pip-licenses]
+commands =
+    pip-licenses {posargs}
+
+


### PR DESCRIPTION
failing workflow: https://github.com/MetOffice/cdk_utils/runs/3218533319?check_suite_focus=true

Added safety and licence check to the tox.ini

